### PR TITLE
Add "Badge" as a Condition for Auth

### DIFF
--- a/lib/DefaultAuthConditions/Badge.luau
+++ b/lib/DefaultAuthConditions/Badge.luau
@@ -1,0 +1,15 @@
+local BadgeService = game:GetService("BadgeService")
+local QueryAuthTypes = require(script.Parent.Parent.Types)
+
+type AuthCondition = QueryAuthTypes.AuthCondition
+
+--[[
+    Checks if the player owns the badge with the given badge ID.
+    @param badgeId number - The badge ID to check against.
+    @return AuthCondition - A lambda that evaluates to see if the player owns the specified badge.
+]]
+return function(badgeId: number): AuthCondition
+	return function(player: Player): boolean
+		return BadgeService:UserHasBadgeAsync(player.UserId, badgeId)
+	end
+end

--- a/lib/init.luau
+++ b/lib/init.luau
@@ -24,6 +24,7 @@ export type QueryAuthModule = {
 	AccountAge: (minimum: number, maximum: number?) -> AuthCondition,
 	Gamepass: (gamepassId: number) -> AuthCondition,
 	Group: (group_id: number, min_rank: number? | string?, max_rank: number? | string?) -> AuthCondition,
+	Badge: (values: number?) -> AuthCondition,
 	FriendsWith: (otherPlayerId: number) -> AuthCondition,
 	ServerTime: (time: number) -> AuthCondition,
 	Throttle: (time: number, mark: (() -> number)?) -> AuthCondition,
@@ -102,6 +103,7 @@ QueryAuth.Premium = require(DefaultAuthConditionsFolder.Premium)
 QueryAuth.AccountAge = require(DefaultAuthConditionsFolder.AccountAge)
 QueryAuth.Gamepass = require(DefaultAuthConditionsFolder.Gamepass)
 QueryAuth.Group = require(DefaultAuthConditionsFolder.Group)
+QueryAuth.Badge = require(DefaultAuthConditionsFolder.Badge)
 QueryAuth.FriendsWith = require(DefaultAuthConditionsFolder.FriendsWith)
 QueryAuth.ServerTime = require(DefaultAuthConditionsFolder.ServerTime)
 QueryAuth.GlobalThrottle = require(DefaultAuthConditionsFolder.GlobalThrottle)


### PR DESCRIPTION
i needed a badge condition for my game so i just decided to add it here to :D

added 
QueryAuth.Badge = require(DefaultAuthConditionsFolder.Badge)
Badge: (values: number?) -> AuthCondition, to the export type QueryAuthModule

the entire module for the badge condition handler (very similar to the gamepass module)